### PR TITLE
fixJsonFile

### DIFF
--- a/app/views/api/schedules/index.json.jbuilder
+++ b/app/views/api/schedules/index.json.jbuilder
@@ -1,9 +1,1 @@
-json.array! @schedules do |schedule|
-  json.name schedule.name
-  json.sche_day schedule.sche_day
-  json.start_time schedule.start_time.strftime("%H:%M")
-  json.finish_time schedule.finish_time.strftime("%H:%M")
-  json.started_time schedule.started_time
-  json.finished_time schedule.finished_time
-  json.color schedule.color
-end
+json.schedules @schedules


### PR DESCRIPTION
### WHY
iPhone側で、何のデータか判断しやすくするため。
### WHAT
jbuilderで配列に格納するのではなく、データを丸ごと渡すよう変更。