### PR TITLE
addedandremovedAuthenticateUser

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  before_action :authenticate_user!
+  # before_action :authenticate_user!
   before_action :configure_permitted_parameters, if: :devise_controller?
   protected
 

--- a/app/controllers/friends_controller.rb
+++ b/app/controllers/friends_controller.rb
@@ -1,4 +1,5 @@
 class FriendsController < ApplicationController
+  before_action :authenticate_user!
   def index
     if params[:keyword] == nil
       @friends = Friend.includes(:user)

--- a/app/controllers/schedules_controller.rb
+++ b/app/controllers/schedules_controller.rb
@@ -1,4 +1,5 @@
 class SchedulesController < ApplicationController
+  before_action :authenticate_user!
   @@i = 0
   def index
     @message = ""


### PR DESCRIPTION
### WHY
api取得時に、ログイン必須とすると、アプリからデータを取得できないため。
### WHAT
application_controllerからbefore_actionを削除し、api以外のその他のコントローラに個別に記載した。